### PR TITLE
Update communityLinks.js

### DIFF
--- a/communityLinks.js
+++ b/communityLinks.js
@@ -55,8 +55,8 @@ const communityLinks = {
       url: "https://t.me/Einundzwanzig_Thurgau"
     },
     {
-      name: "Bitcoin Alps",
-      url: "https://t.me/bitcoin_alps"
+      name: "Bitcoin Weesen SG",
+      url: "https://www.bitcoinweesen.ch"
     }
   ],
   'Info Gruppen': [


### PR DESCRIPTION
deleted double entry in category "Regionale Gruppen" (bitcoin Alps) and replaced it with "Bitcoin Weesen SG"