### PR TITLE
Replace 'Lipa' with 'Fortego' in communityLinks.js

### DIFF
--- a/datasets/communityLinks.js
+++ b/datasets/communityLinks.js
@@ -183,8 +183,8 @@ const communityLinks = {
   ],
   Dienstleister: [
     {
-      name: "Lipa",
-      url: "https://lipa.swiss",
+      name: "Fortego",
+      url: "https://fortego.ch",
     },
     {
       name: "Pocket",


### PR DESCRIPTION
I replaced Lipa with Fortego, the new Project from Adrian and Basti, lipa doesn't exist anymore, sadly...